### PR TITLE
This fix removes 'All' and 'Scheme' as attach points. Splunk will kill t...

### DIFF
--- a/src/Splunk.ModularInputs/Splunk/ModularInputs/DebuggerAttachPoints.cs
+++ b/src/Splunk.ModularInputs/Splunk/ModularInputs/DebuggerAttachPoints.cs
@@ -31,9 +31,7 @@ namespace Splunk.ModularInputs
     public enum DebuggerAttachPoints
     {
         None=0,
-        Scheme=1,
-        ValidateArguments=2,
-        StreamEvents=4,
-        All=8
+        ValidateArguments=1,
+        StreamEvents=2,
     }
 }

--- a/src/Splunk.ModularInputs/Splunk/ModularInputs/ModularInput.cs
+++ b/src/Splunk.ModularInputs/Splunk/ModularInputs/ModularInput.cs
@@ -99,14 +99,9 @@ namespace Splunk.ModularInputs
                 return false;
             }
 
-            if (IsAttachPointAll(attachPoints))
-            {
-                return true;
-            }
-
             if (args.Length > 0)
             {
-                if (IsScheme(args, attachPoints) || IsValidateArguments(args, attachPoints))
+                if (IsValidateArguments(args, attachPoints))
                 {
                     return true;
                 }
@@ -117,11 +112,6 @@ namespace Splunk.ModularInputs
             }
 
             return false;
-        }
-
-        private static bool IsAttachPointAll(DebuggerAttachPoints attachPoints)
-        {
-            return attachPoints == DebuggerAttachPoints.All;
         }
 
         private static bool IsAttachPointNone(DebuggerAttachPoints attachPoints)
@@ -140,11 +130,6 @@ namespace Splunk.ModularInputs
                     ((attachPoints & DebuggerAttachPoints.ValidateArguments) == DebuggerAttachPoints.ValidateArguments));
         }
 
-        private static bool IsScheme(string[] args, DebuggerAttachPoints attachPoints)
-        {
-            return (args[0].ToLower().Equals("--scheme") &&
-                    ((attachPoints & DebuggerAttachPoints.Scheme) == DebuggerAttachPoints.Scheme));
-        }
 
         /// <summary>
         /// Performs the action specified by the <paramref name="args"/> parameter.

--- a/test/unit-tests/TestModularInputsDebugging.cs
+++ b/test/unit-tests/TestModularInputsDebugging.cs
@@ -91,15 +91,6 @@ namespace Splunk.ModularInputs.UnitTests
 
         [Trait("unit-test", "Splunk.ModularInputs.ModularInput")]
         [Fact]
-        public void ShouldWaitForAttachReturnsTrueWhenSchemeArgIsPassed()
-        {
-            var args = new[] { "--scheme" };
-            var shouldWait = ModularInput.ShouldWaitForDebuggerToAttach(args, DebuggerAttachPoints.Scheme);
-            Assert.True(shouldWait);
-        }
-
-        [Trait("unit-test", "Splunk.ModularInputs.ModularInput")]
-        [Fact]
         public void ShoulldWaitForAttachReturnsTrueWhenValidateArgumentsArgIsPassed()
         {
             var args = new[] { "--validate-arguments" };
@@ -113,23 +104,6 @@ namespace Splunk.ModularInputs.UnitTests
         {
             var args = new string[0];
             var shouldWait = ModularInput.ShouldWaitForDebuggerToAttach(args, DebuggerAttachPoints.StreamEvents);
-            Assert.True(shouldWait);
-        }
-
-        [Trait("unit-test", "Splunk.ModularInputs.ModularInput")]
-        [Fact]
-        public void ShouldWaitForDebuggerToAttachReturnsTrueWhenAllIsPassed()
-        {
-            var args = new string[] { "--scheme" };
-            var shouldWait = ModularInput.ShouldWaitForDebuggerToAttach(args, DebuggerAttachPoints.All);
-            Assert.True(shouldWait);
-
-            args = new string[] { "--validate-arguments" };
-            shouldWait = ModularInput.ShouldWaitForDebuggerToAttach(args, DebuggerAttachPoints.All);
-            Assert.True(shouldWait);
-            
-            args = new string[0];
-            shouldWait = ModularInput.ShouldWaitForDebuggerToAttach(args, DebuggerAttachPoints.All);
             Assert.True(shouldWait);
         }
 
@@ -156,7 +130,7 @@ namespace Splunk.ModularInputs.UnitTests
         {
             Assert.Throws<ArgumentOutOfRangeException>(() =>
             {
-                ModularInput.Run<TestDebugInput>(new string[0], DebuggerAttachPoints.All, 0);
+                ModularInput.Run<TestDebugInput>(new string[0], DebuggerAttachPoints.StreamEvents, 0);
             });
         }
 


### PR DESCRIPTION
...he process if it does not immediately return a result
