### PR TITLE
Stopgap fix for graceful shutdown of modular inputs.

### DIFF
--- a/src/Splunk.ModularInputs/Splunk.ModularInputs.csproj
+++ b/src/Splunk.ModularInputs/Splunk.ModularInputs.csproj
@@ -114,7 +114,24 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="Splunk\ModularInputs\**\*" />
+    <Compile Include="Splunk\ModularInputs\Argument.cs" />
+    <Compile Include="Splunk\ModularInputs\DataType.cs" />
+    <Compile Include="Splunk\ModularInputs\DebuggerAttachPoints.cs" />
+    <Compile Include="Splunk\ModularInputs\Event.cs" />
+    <Compile Include="Splunk\ModularInputs\EventWriter.cs" />
+    <Compile Include="Splunk\ModularInputs\InputDefinition.cs" />
+    <Compile Include="Splunk\ModularInputs\InputDefinitionCollection.cs" />
+    <Compile Include="Splunk\ModularInputs\ISplunkTerminationWatcher.cs" />
+    <Compile Include="Splunk\ModularInputs\ModularInput.cs" />
+    <Compile Include="Splunk\ModularInputs\MultiValueParameter.cs" />
+    <Compile Include="Splunk\ModularInputs\Parameter.cs" />
+    <Compile Include="Splunk\ModularInputs\Scheme.cs" />
+    <Compile Include="Splunk\ModularInputs\Severity.cs" />
+    <Compile Include="Splunk\ModularInputs\SingleValueParameter.cs" />
+    <Compile Include="Splunk\ModularInputs\SplunkTerminationWatcher.cs" />
+    <Compile Include="Splunk\ModularInputs\StreamingMode.cs" />
+    <Compile Include="Splunk\ModularInputs\Util.cs" />
+    <Compile Include="Splunk\ModularInputs\Validation.cs" />
     <None Include="packages.config" />
     <None Include="Splunk.ModularInputs.nuspec" />
   </ItemGroup>

--- a/src/Splunk.ModularInputs/Splunk.ModularInputs.csproj
+++ b/src/Splunk.ModularInputs/Splunk.ModularInputs.csproj
@@ -114,29 +114,14 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="Splunk\ModularInputs\Argument.cs" />
-    <Compile Include="Splunk\ModularInputs\DataType.cs" />
-    <Compile Include="Splunk\ModularInputs\DebuggerAttachPoints.cs" />
-    <Compile Include="Splunk\ModularInputs\Event.cs" />
-    <Compile Include="Splunk\ModularInputs\EventWriter.cs" />
-    <Compile Include="Splunk\ModularInputs\InputDefinition.cs" />
-    <Compile Include="Splunk\ModularInputs\InputDefinitionCollection.cs" />
-    <Compile Include="Splunk\ModularInputs\ISplunkTerminationWatcher.cs" />
-    <Compile Include="Splunk\ModularInputs\ModularInput.cs" />
-    <Compile Include="Splunk\ModularInputs\MultiValueParameter.cs" />
-    <Compile Include="Splunk\ModularInputs\Parameter.cs" />
-    <Compile Include="Splunk\ModularInputs\Scheme.cs" />
-    <Compile Include="Splunk\ModularInputs\Severity.cs" />
-    <Compile Include="Splunk\ModularInputs\SingleValueParameter.cs" />
-    <Compile Include="Splunk\ModularInputs\SplunkTerminationWatcher.cs" />
-    <Compile Include="Splunk\ModularInputs\StreamingMode.cs" />
-    <Compile Include="Splunk\ModularInputs\Util.cs" />
-    <Compile Include="Splunk\ModularInputs\Validation.cs" />
+    <Compile Include="Splunk\ModularInputs\**\*" />
     <None Include="packages.config" />
     <None Include="Splunk.ModularInputs.nuspec" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System" />
+    <Reference Include="System.Management" />
+    <Reference Include="System.ServiceProcess" />
     <Reference Include="System.XML" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Splunk.ModularInputs/Splunk/ModularInputs/Event.cs
+++ b/src/Splunk.ModularInputs/Splunk/ModularInputs/Event.cs
@@ -69,7 +69,7 @@ namespace Splunk.ModularInputs
             {
                 double timestamp = (Time.Value.Ticks - ticksSinceEpoch) / TimeSpan.TicksPerSecond;
                 writer.WriteStartElement("time");
-                writer.WriteString(timestamp.ToString());
+                writer.WriteString(string.Format("{0}.{1}", timestamp.ToString(), Time.Value.Millisecond));
                 writer.WriteEndElement();
             }
 

--- a/src/Splunk.ModularInputs/Splunk/ModularInputs/EventWriter.cs
+++ b/src/Splunk.ModularInputs/Splunk/ModularInputs/EventWriter.cs
@@ -22,6 +22,7 @@ namespace Splunk.ModularInputs
     using System.Diagnostics;
     using System.IO;
     using System.Linq;
+    using System.Runtime.CompilerServices;
     using System.Text;
     using System.Threading;
     using System.Threading.Tasks;
@@ -98,8 +99,15 @@ namespace Splunk.ModularInputs
                 // Don't start the eventQueueMonitor up until we actually want to write
                 // events so we don't get empty <stream/> elements in cases where
                 // we don't actually queue anything.
-                eventQueueMonitor = Task.Run(() => WriteEventsFromQueue());
+                StartEventQueueMonitor();
             await Task.Run(() => eventQueue.Add(e));
+        }
+
+        [MethodImpl(MethodImplOptions.Synchronized)]
+        private void StartEventQueueMonitor()
+        {
+            if (eventQueueMonitor == null)
+                eventQueueMonitor = Task.Run(() => WriteEventsFromQueue());
         }
 
         public async Task CompleteAsync()

--- a/src/Splunk.ModularInputs/Splunk/ModularInputs/EventWriter.cs
+++ b/src/Splunk.ModularInputs/Splunk/ModularInputs/EventWriter.cs
@@ -51,6 +51,8 @@ namespace Splunk.ModularInputs
         private Task eventQueueMonitor = null;
         private object synchronizationObject = new object();
         private bool completed;
+        private bool stopWritingEvents = false;
+        private CancellationTokenSource cancelEventWriting = new CancellationTokenSource();
         #endregion
 
         #region Properties
@@ -75,12 +77,18 @@ namespace Splunk.ModularInputs
         /// This is the easiest way to trigger behavior after events are actually
         /// written to Splunk. In production, it will usually be an instance
         /// of Progress&lt;EventWrittenProgressReport&gt;</param>
+        /// <param name="boundedCapacity">The maximum size for the event queue.
+        /// When the queue size reaches this capacity, the QueueEventForWriting
+        /// method task will block until space in the queue becomes available
+        /// to add the event.</param>
         public EventWriter(TextWriter stdout, TextWriter stderr,
-            IProgress<EventWrittenProgressReport> progress)
+            IProgress<EventWrittenProgressReport> progress, int boundedCapacity = 0)
         {
             this.Stdout = stdout;
             this.Stderr = stderr;
             this.Progress = progress;
+            if (boundedCapacity > 0)
+                this.eventQueue = new BlockingCollection<Event>(boundedCapacity);
         }
 
         #endregion
@@ -100,7 +108,22 @@ namespace Splunk.ModularInputs
                 // events so we don't get empty <stream/> elements in cases where
                 // we don't actually queue anything.
                 StartEventQueueMonitor();
-            await Task.Run(() => eventQueue.Add(e));
+            await Task.Run(() => QueueEvent(e));
+        }
+
+        private void QueueEvent(Event e)
+        {
+            try
+            {
+                if (cancelEventWriting.IsCancellationRequested)
+                    return;
+
+                eventQueue.Add(e, cancelEventWriting.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                //suppress
+            }
         }
 
         [MethodImpl(MethodImplOptions.Synchronized)]
@@ -108,6 +131,18 @@ namespace Splunk.ModularInputs
         {
             if (eventQueueMonitor == null)
                 eventQueueMonitor = Task.Run(() => WriteEventsFromQueue());
+        }
+
+        /// <summary>
+        /// Causes the event writer to stop writing queued events to Splunk.
+        /// This is intended for use when Splunk shutdown has been detected,
+        /// and it's no longer certain that Splunk is reading events from the modular
+        /// input. Events can still be added to the queue, they'll just never be
+        /// sent to Splunk and never reach the progress reporter.
+        /// </summary>
+        public void StopWritingEvents()
+        {
+            cancelEventWriting.Cancel();
         }
 
         public async Task CompleteAsync()
@@ -173,20 +208,27 @@ namespace Splunk.ModularInputs
             // method.
             Stdout.WriteLine("<stream>");
 
-            foreach (Event eventToWrite in eventQueue.GetConsumingEnumerable())
+            try
             {
-                var buffer = new StringWriter();
-                using (var writer = XmlWriter.Create(buffer, new XmlWriterSettings { ConformanceLevel = ConformanceLevel.Fragment }))
+                foreach (Event eventToWrite in eventQueue.GetConsumingEnumerable(cancelEventWriting.Token))
                 {
-                    eventToWrite.ToXml(writer);
+                    var buffer = new StringWriter();
+                    using (var writer = XmlWriter.Create(buffer, new XmlWriterSettings { ConformanceLevel = ConformanceLevel.Fragment }))
+                    {
+                        eventToWrite.ToXml(writer);
+                    }
+                    Stdout.WriteLine(buffer.ToString());
+                    Stdout.Flush();
+                    this.Progress.Report(new EventWrittenProgressReport
+                    {
+                        Timestamp = DateTime.Now,
+                        WrittenEvent = eventToWrite
+                    });
                 }
-                Stdout.WriteLine(buffer.ToString());
-                Stdout.Flush();
-                this.Progress.Report(new EventWrittenProgressReport
-                {
-                    Timestamp = DateTime.Now,
-                    WrittenEvent = eventToWrite
-                });
+            }
+            catch (OperationCanceledException)
+            {
+                //suppress
             }
 
             Stdout.WriteLine("</stream>");

--- a/src/Splunk.ModularInputs/Splunk/ModularInputs/ISplunkTerminationWatcher.cs
+++ b/src/Splunk.ModularInputs/Splunk/ModularInputs/ISplunkTerminationWatcher.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Splunk.ModularInputs
+{
+    public interface ISplunkTerminationWatcher
+    {
+        /// <summary>
+        /// A flag indicating if Splunk is in the process of shutting down.
+        /// </summary>
+        bool ShutdownRequested { get; }
+        /// <summary>
+        /// A flag indicating if Splunk has terminated.
+        /// </summary>
+        bool SplunkTerminated { get; }
+        /// <summary>
+        /// An event handler that fires when Splunk is being shut down.
+        /// </summary>
+        event EventHandler<EventArgs> ShutdownRequestedEvent;
+        /// <summary>
+        /// An event that fires if the Splunk process terminates.
+        /// </summary>
+        event EventHandler<EventArgs> SplunkTerminatedEvent;
+    }
+}

--- a/src/Splunk.ModularInputs/Splunk/ModularInputs/SplunkTerminationWatcher.cs
+++ b/src/Splunk.ModularInputs/Splunk/ModularInputs/SplunkTerminationWatcher.cs
@@ -1,0 +1,156 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Management;
+using System.Runtime.CompilerServices;
+using System.ServiceProcess;
+using System.Text;
+using System.Threading.Tasks;
+using Splunk.ModularInputs;
+
+namespace Splunk.ModularInputs
+{
+    /// <summary>
+    /// This class watches for events realted to Splunk shutting down or
+    /// terminating. Hooking these events allows a modular input to gracefully
+    /// shutdown (stop sending events to Splunk and save checkpoint data).
+    /// </summary>
+    public class SplunkTerminationWatcher : ISplunkTerminationWatcher, IDisposable
+    {
+        private bool eventFired = false;
+        private EventWriter writer;
+        private ServiceController splunkService;
+
+        public SplunkTerminationWatcher(EventWriter eventWriter)
+        {
+            this.writer = eventWriter;
+
+            ShutdownRequested = false;
+            SplunkTerminated = false;
+            Console.CancelKeyPress += TrapControlSignals;
+
+            uint parentProcessId = GetParentProcessId();
+
+            if (parentProcessId > 0)
+            {
+                Process parentProcess = Process.GetProcessById((int)parentProcessId);
+                parentProcess.EnableRaisingEvents = true;
+                parentProcess.Exited += parentProcess_Exited;
+            }
+
+            splunkService = GetServiceByProcessId(parentProcessId);
+
+            if (splunkService != null)
+            {
+                // Watch the Splunk service, waiting for it to enter a stopping or stopped state.
+                // While this isn't a true fix for the Splunks issues with graceful shutdown of modular
+                // inputs, watching the Splunk service state gives us notification of a shutdown about
+                // 1-2 seconds before the ctrl+break signal is received.
+                Task.Run(() => WatchServiceStateChange(splunkService, ServiceControllerStatus.StopPending));
+                Task.Run(() => WatchServiceStateChange(splunkService, ServiceControllerStatus.Stopped));
+            }
+        }
+
+        /// <summary>
+        /// Handle trapping of ctrl+break and ctrl+c signals.
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void TrapControlSignals(object sender, ConsoleCancelEventArgs e)
+        {
+            if (e.SpecialKey == ConsoleSpecialKey.ControlBreak || e.SpecialKey == ConsoleSpecialKey.ControlC)
+            {
+                if (writer != null)
+                    writer.LogAsync(Severity.Info, "Splunk signaled shutdown via control signal.").Wait();
+
+                FireShutdownEvent();
+                e.Cancel = true;
+                return;
+            }
+            e.Cancel = false;
+        }
+
+        /// <summary>
+        /// Watch for state change of a windows service.
+        /// </summary>
+        /// <param name="parentProcessId"></param>
+        private void WatchServiceStateChange(ServiceController service, ServiceControllerStatus stateToWatch)
+        {
+            service.WaitForStatus(stateToWatch);
+            if (writer != null)
+                writer.LogAsync(Severity.Info, string.Format("Splunk windows service {0} state detected.", Enum.GetName(typeof(ServiceControllerStatus), stateToWatch))).Wait();
+            FireShutdownEvent();
+        }
+
+        private ServiceController GetServiceByProcessId(uint processId)
+        {
+            SelectQuery query = new SelectQuery("Win32_Service", string.Format("ProcessId={0}", processId), new string[] { "Name" });
+            ManagementObjectSearcher searcher = new ManagementObjectSearcher(new ManagementScope("root\\CIMV2"), query);
+            System.Management.ManagementObjectCollection.ManagementObjectEnumerator enumerator = searcher.Get().GetEnumerator();
+            if (enumerator.MoveNext() == false)
+            {
+                //Couldn't find a service with the given process ID
+                return null;
+            }
+            string serviceName = (string)enumerator.Current["Name"];
+
+            return new ServiceController(serviceName);
+        }
+
+        private uint GetParentProcessId()
+        {
+            int myProcessId = Process.GetCurrentProcess().Id;
+            SelectQuery query = new SelectQuery("Win32_Process", string.Format("ProcessId={0}", myProcessId), new string[] { "ParentProcessId" });
+            ManagementObjectSearcher searcher = new ManagementObjectSearcher(new ManagementScope("root\\CIMV2"), query);
+            System.Management.ManagementObjectCollection.ManagementObjectEnumerator enumerator = searcher.Get().GetEnumerator();
+            if (enumerator.MoveNext() == false)
+            {
+                //Couldn't hook the parent process. There may not be one.
+                return 0;
+            }
+            return (uint)enumerator.Current["ParentProcessId"];
+        }
+
+        void parentProcess_Exited(object sender, EventArgs e)
+        {
+            if (writer != null)
+                writer.LogAsync(Severity.Info, "Splunk process termination detected.").Wait();
+            SplunkTerminated = true;
+            if (SplunkTerminatedEvent != null)
+            {
+                foreach (EventHandler<EventArgs> handler in SplunkTerminatedEvent.GetInvocationList())
+                {
+                    handler.BeginInvoke(this, new EventArgs(), null, null);
+                }
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.Synchronized)]
+        private void FireShutdownEvent(){
+            if (eventFired == false)
+            {
+                ShutdownRequested = true;
+                if (ShutdownRequestedEvent != null)
+                {
+                    foreach (EventHandler<EventArgs> handler in ShutdownRequestedEvent.GetInvocationList())
+                    {
+                        handler.BeginInvoke(this, new EventArgs(), null, null);
+                    }
+                }
+                eventFired = true;
+            }
+        }
+
+        public bool ShutdownRequested { get; private set; }
+        public bool SplunkTerminated { get; private set; }
+        public event EventHandler<EventArgs> ShutdownRequestedEvent;
+        public event EventHandler<EventArgs> SplunkTerminatedEvent;
+
+        public void Dispose()
+        {
+            if(splunkService != null)
+                splunkService.Dispose();
+        }
+    }
+}


### PR DESCRIPTION
This set of changes is a stopgap attempt to fix some of the issues around graceful shutdown of modular inputs when Splunk itself is shutting down. See [this issue](https://github.com/splunk/splunk-sdk-csharp-pcl/issues/37) for details.

This change attempts to avoid the issue of lost events by:
1. Providing a mechanism to stop writing events to Splunk. After the "Stop writing" is triggered, any queued events are simply not written, and thus are not passed to the progress reporter.
2. Watching the Splunk Windows service to enter the Stopping or Stopped states. On average this gives the modular input 1-2 seconds lead time before Splunk signals the modular input to shut down via ctrl+break.