### PR TITLE
removed redundant StyleCop package

### DIFF
--- a/examples/list_apps/packages.config
+++ b/examples/list_apps/packages.config
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="StyleCop" version="4.7.49.0" targetFramework="net45" />
   <package id="StyleCop.MSBuild" version="4.7.49.0" targetFramework="net45" developmentDependency="true" />
 </packages>

--- a/examples/mock-context/packages.config
+++ b/examples/mock-context/packages.config
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="StyleCop" version="4.7.49.0" targetFramework="net45" />
   <package id="StyleCop.MSBuild" version="4.7.49.0" targetFramework="net45" developmentDependency="true" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
 </packages>

--- a/examples/normal-search/packages.config
+++ b/examples/normal-search/packages.config
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="StyleCop" version="4.7.49.0" targetFramework="net45" />
   <package id="StyleCop.MSBuild" version="4.7.49.0" targetFramework="net45" developmentDependency="true" />
 </packages>

--- a/examples/search/packages.config
+++ b/examples/search/packages.config
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="StyleCop" version="4.7.49.0" targetFramework="net45" />
   <package id="StyleCop.MSBuild" version="4.7.49.0" targetFramework="net45" developmentDependency="true" />
 </packages>

--- a/examples/submit/packages.config
+++ b/examples/submit/packages.config
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="StyleCop" version="4.7.49.0" targetFramework="net45" />
   <package id="StyleCop.MSBuild" version="4.7.49.0" targetFramework="net45" developmentDependency="true" />
 </packages>

--- a/src/Splunk.Client.Helpers/packages.config
+++ b/src/Splunk.Client.Helpers/packages.config
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="StyleCop" version="4.7.49.0" targetFramework="net45" />
   <package id="StyleCop.MSBuild" version="4.7.49.0" targetFramework="net45" developmentDependency="true" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
 </packages>

--- a/test/acceptance-tests/packages.config
+++ b/test/acceptance-tests/packages.config
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="StyleCop" version="4.7.49.0" targetFramework="net45" />
   <package id="StyleCop.MSBuild" version="4.7.49.0" targetFramework="net45" developmentDependency="true" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
   <package id="xunit.runner.visualstudio" version="2.0.0-rc1-build1030" targetFramework="net45" />

--- a/test/unit-tests/packages.config
+++ b/test/unit-tests/packages.config
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="StyleCop" version="4.7.49.0" targetFramework="net45" />
   <package id="StyleCop.MSBuild" version="4.7.49.0" targetFramework="net45" developmentDependency="true" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
   <package id="xunit.runner.visualstudio" version="2.0.0-rc1-build1030" targetFramework="net45" />


### PR DESCRIPTION
You only need to install the StyleCop package if you want to reference the lib and build custom rules, which this solution does not do. To run StyleCop analysis, all you need is StyleCop.MSBuild.

As an aside, I also noticed that two projects (Splunk.Client and Splunk.ModularInputs) have both BuildTools.StyleCop *and* StyleCop.MSBuild installed. You only need one of them. The difference between the two is that StyleCop.MSBuild only installs the targets required for analysis to run and it uses the built-in facility in NuGet (build folder) to do this. BuildTools.StyleCop does the same thing but it uses PowerShell (Install.ps1) to inject the targets into the csproj which introduces x-plat issues. BuildTools.StyleCop also adds PowerShell functions to control the settings but obviously these are also liable to x-plat problems.