### PR TITLE
Fix for missing millisecond component when writing timestamp.

### DIFF
--- a/src/Splunk.ModularInputs/Splunk/ModularInputs/Event.cs
+++ b/src/Splunk.ModularInputs/Splunk/ModularInputs/Event.cs
@@ -67,9 +67,9 @@ namespace Splunk.ModularInputs
 
             if (Time.HasValue)
             {
-                double timestamp = (Time.Value.Ticks - ticksSinceEpoch) / TimeSpan.TicksPerSecond;
+                double timestamp = (double)(Time.Value.Ticks - ticksSinceEpoch) / TimeSpan.TicksPerSecond;
                 writer.WriteStartElement("time");
-                writer.WriteString(string.Format("{0}.{1:D3}", timestamp, Time.Value.Millisecond));
+                writer.WriteString(timestamp.ToString());
                 writer.WriteEndElement();
             }
 

--- a/src/Splunk.ModularInputs/Splunk/ModularInputs/Event.cs
+++ b/src/Splunk.ModularInputs/Splunk/ModularInputs/Event.cs
@@ -69,7 +69,7 @@ namespace Splunk.ModularInputs
             {
                 double timestamp = (Time.Value.Ticks - ticksSinceEpoch) / TimeSpan.TicksPerSecond;
                 writer.WriteStartElement("time");
-                writer.WriteString(timestamp.ToString());
+                writer.WriteString(string.Format("{0}.{1:D3}", timestamp, Time.Value.Millisecond));
                 writer.WriteEndElement();
             }
 


### PR DESCRIPTION
When writing out an Event to Splunk, the millisecond component of the timestamp was not being written. This would cause all event times to have their milliseconds set to 0.