### PR TITLE
Stream reader encoding

### DIFF
--- a/src/Splunk.Client/Splunk/Client/Response.cs
+++ b/src/Splunk.Client/Splunk/Client/Response.cs
@@ -23,6 +23,7 @@ namespace Splunk.Client
     using System.Net.Http;
     using System.Threading.Tasks;
     using System.Xml;
+	using System.Text;
 
     /// <summary>
     /// Represents a Splunk service response.
@@ -62,6 +63,14 @@ namespace Splunk.Client
         /// </value>
         public Stream Stream
         { get; private set; }
+
+        /// <summary>
+        /// Override the encoding used to parse the Reponse to prevent parsing exception.
+        /// This is useful if the response contains illegal characters that do not comply with the Xml Prolog.
+        /// For example the response contains unicode, whereas xml Prolog is <?xml version='1.0' encoding='UTF-8'?>
+        /// Leave null to use xml Prolog encoding.
+        /// </summary>
+        public static Encoding StreamResultEncoding { get; set; }
 
         /// <summary>
         /// Gets the <see cref="XmlReader"/> for reading HTTP body data from the

--- a/src/Splunk.Client/Splunk/Client/Response.cs
+++ b/src/Splunk.Client/Splunk/Client/Response.cs
@@ -23,7 +23,7 @@ namespace Splunk.Client
     using System.Net.Http;
     using System.Threading.Tasks;
     using System.Xml;
-	using System.Text;
+    using System.Text;
 
     /// <summary>
     /// Represents a Splunk service response.

--- a/src/Splunk.Client/Splunk/Client/Response.cs
+++ b/src/Splunk.Client/Splunk/Client/Response.cs
@@ -82,7 +82,7 @@ namespace Splunk.Client
         public XmlReader XmlReader
         {
             get
-			{
+            {
                 if (this.reader == null)
                 {
                     if (StreamResultEncoding != null)
@@ -93,7 +93,7 @@ namespace Splunk.Client
                 return this.reader;
             }
         }
-
+        
         #endregion
 
         #region Methods

--- a/src/Splunk.Client/Splunk/Client/Response.cs
+++ b/src/Splunk.Client/Splunk/Client/Response.cs
@@ -80,14 +80,16 @@ namespace Splunk.Client
         /// The XML reader.
         /// </value>
         public XmlReader XmlReader
-        { 
-            get 
-            { 
+        {
+            get
+			{
                 if (this.reader == null)
                 {
-                    this.reader = XmlReader.Create(this.Stream, XmlReaderSettings);
+                    if (StreamResultEncoding != null)
+                        this.reader = XmlReader.Create(new StreamReader(this.Stream, Response.StreamResultEncoding), XmlReaderSettings);
+                    else
+                        this.reader = XmlReader.Create(this.Stream, XmlReaderSettings);
                 }
-
                 return this.reader;
             }
         }


### PR DESCRIPTION
Ability to override the encoding used to parse the Reponse to prevent parsing exception.
This is useful if the response contains illegal characters that do not comply with the Xml Prolog.
For example the response contains unicode, whereas xml Prolog is <?xml version='1.0' encoding='UTF-8'?>. Leave null to use xml Prolog encoding.