### PR TITLE
Handle cases where we get an empty key for an s:dict entry

### DIFF
--- a/src/Splunk.Client/Splunk/Client/AtomEntry.cs
+++ b/src/Splunk.Client/Splunk/Client/AtomEntry.cs
@@ -389,6 +389,21 @@ namespace Splunk.Client
                     string propertyName;
                     dynamic propertyValue;
 
+                    // There are cases where the server sends us bad values for "s:key", namely
+                    // the empty string. This happens for example when we get back the metadata for
+                    // a search job which contains an "eval". In these cases, we simply replace the
+                    // empty string with a literal string called "empty", so that we know where it came
+                    // from.
+                    //
+                    // The risk with this fix is that we will have multiple empty keys at the same 
+                    // level, and thus using "empty" would clash. However, this would be an even more
+                    // serious error on the part of the API, as it would mean we have no way to disambiguate
+                    // those two entries. As such, we feel it is safe.
+                    if (names[names.Length - 1] == "")
+                    {
+                        names[names.Length - 1] = "empty";
+                    }
+
                     for (int i = 0; i < names.Length - 1; i++)
                     {
                         propertyName = NormalizePropertyName(names[i]);


### PR DESCRIPTION
When EAI sends us s:dict entries (with nested s:key nodes), we parse
them as a dictionary in C#. However, it turns out the API can send us
a case where the value for the s:key node is actually the empty string,
which we do not expect and actually have a code contract to protect
against.

In that case, we will change it from the empty string to the string
called "empty" to be explicit about it. Since there can only be one
empty key per level (otherwise it would be a serious API error), this
is a reasonable workaround.