### PR TITLE
Updates `System.Collections.Immutable` dependency

### DIFF
--- a/src/Splunk.Client/Splunk.Client.nuspec
+++ b/src/Splunk.Client/Splunk.Client.nuspec
@@ -15,7 +15,7 @@
     <tags>Splunk</tags>
     <language>en-US</language>
     <dependencies>
-      <dependency id="System.Collections.Immutable" version="[1.1.37,1.2.0)" />
+      <dependency id="System.Collections.Immutable" version="[1.1.37,2)" />
     </dependencies>
   </metadata>
   <files>

--- a/src/Splunk.Client/packages.config
+++ b/src/Splunk.Client/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="BuildTools.StyleCop" version="4.7.49.0" targetFramework="portable-net45+win8" developmentDependency="true" />
   <package id="StyleCop.MSBuild" version="4.7.49.0" targetFramework="portable-net45+win8" developmentDependency="true" />
-  <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8+wpa81" />
+  <package id="System.Collections.Immutable" version="1.3.1" targetFramework="portable45-net45+win8+wpa81" />
 </packages>


### PR DESCRIPTION
This is the "quick fix" for the `System.Collections.Immutable` dependency bug, and resolves #64 .

This is needed to support any of the modern .NET platforms (UWP, ASP.NET Core, .NET Standard). 

Let me know if there's any changes required or questions/issues.