### PR TITLE
Avoid using the call to System.Diagnostics.Requires

### DIFF
--- a/src/Splunk.Client.Helpers/Splunk/Client/Helpers/MockContext.cs
+++ b/src/Splunk.Client.Helpers/Splunk/Client/Helpers/MockContext.cs
@@ -107,7 +107,7 @@ namespace Splunk.Client.Helpers
 
         public static void Begin(string callerId)
         {
-            Contract.Requires<ArgumentNullException>(callerId != null);
+            Client.Contract.Requires<ArgumentNullException>(callerId != null);
             
             RecordingFilename = Path.Combine(recordingDirectoryName, string.Join(".", callerId, "json", "gz"));
 
@@ -353,8 +353,8 @@ namespace Splunk.Client.Helpers
 
             protected static async Task<Tuple<string, long>> ComputeChecksum(HttpRequestMessage request, MemoryStream stream)
             {
-                Contract.Requires<ArgumentNullException>(request != null);
-                Contract.Requires<ArgumentNullException>(stream != null);
+                Splunk.Client.Contract.Requires<ArgumentNullException>(request != null);
+                Splunk.Client.Contract.Requires<ArgumentNullException>(stream != null);
 
                 string text;
                 byte[] bytes;
@@ -403,7 +403,7 @@ namespace Splunk.Client.Helpers
             protected static async Task<Tuple<string, HttpRequestMessage>> DuplicateAndComputeChecksum(
                 HttpRequestMessage request)
             {
-                Contract.Requires<ArgumentNullException>(request != null);
+                Splunk.Client.Contract.Requires<ArgumentNullException>(request != null);
                 var stream = new MemoryStream();
 
                 try
@@ -596,9 +596,9 @@ namespace Splunk.Client.Helpers
 
             Recording(HttpResponseMessage response, byte[] content, string checksum)
             {
-                Contract.Requires<ArgumentNullException>(response != null);
-                Contract.Requires<ArgumentNullException>(content != null);
-                Contract.Requires<ArgumentNullException>(checksum != null);
+                Client.Contract.Requires<ArgumentNullException>(response != null);
+                Client.Contract.Requires<ArgumentNullException>(content != null);
+                Client.Contract.Requires<ArgumentNullException>(checksum != null);
 
                 this.checksum = checksum;
                 this.content = Convert.ToBase64String(content);

--- a/src/Splunk.Client.Helpers/Splunk/Client/Helpers/MockContext.cs
+++ b/src/Splunk.Client.Helpers/Splunk/Client/Helpers/MockContext.cs
@@ -22,7 +22,6 @@ namespace Splunk.Client.Helpers
     using System.Collections.Generic;
     using System.Configuration;
     using System.Diagnostics;
-    using System.Diagnostics.Contracts;
     using System.IO;
     using System.IO.Compression;
     using System.Linq;

--- a/src/Splunk.Client.Helpers/Splunk/Client/Helpers/MockContextAttribute.cs
+++ b/src/Splunk.Client.Helpers/Splunk/Client/Helpers/MockContextAttribute.cs
@@ -16,21 +16,7 @@
 
 namespace Splunk.Client.Helpers
 {
-    using Splunk.Client;
-    using System;
-    using System.Collections.Generic;
-    using System.Configuration;
-    using System.Diagnostics.Contracts;
-    using System.IO;
-    using System.Linq;
-    using System.Net;
-    using System.Net.Http;
     using System.Reflection;
-    using System.Runtime.Serialization;
-    using System.Security.Cryptography;
-    using System.Text;
-    using System.Threading;
-    using System.Threading.Tasks;
     using Xunit;
 
     /// <summary>

--- a/src/Splunk.Client/Splunk/Client/Application.cs
+++ b/src/Splunk.Client/Splunk/Client/Application.cs
@@ -23,7 +23,6 @@ namespace Splunk.Client
     using System;
     using System.Collections.Generic;
     using System.ComponentModel;
-    using System.Diagnostics.Contracts;
     using System.Linq;
     using System.Net;
     using System.Runtime.Serialization;

--- a/src/Splunk.Client/Splunk/Client/Argument.cs
+++ b/src/Splunk.Client/Splunk/Client/Argument.cs
@@ -17,7 +17,6 @@
 namespace Splunk.Client
 {
     using System;
-    using System.Diagnostics.Contracts;
     using System.Globalization;
 
     /// <summary>

--- a/src/Splunk.Client/Splunk/Client/ArgumentSet.cs
+++ b/src/Splunk.Client/Splunk/Client/ArgumentSet.cs
@@ -23,7 +23,6 @@ namespace Splunk.Client
     using System;
     using System.Collections;
     using System.Collections.Generic;
-    using System.Diagnostics.Contracts;
     using System.Linq;
 
     /// <summary>

--- a/src/Splunk.Client/Splunk/Client/AtomEntry.cs
+++ b/src/Splunk.Client/Splunk/Client/AtomEntry.cs
@@ -26,8 +26,6 @@ namespace Splunk.Client
     using System;
     using System.Collections.Generic;
     using System.Collections.ObjectModel;
-    using System.Diagnostics.Contracts;
-    using System.Dynamic;
     using System.Globalization;
     using System.IO;
     using System.Text;

--- a/src/Splunk.Client/Splunk/Client/AtomFeed.cs
+++ b/src/Splunk.Client/Splunk/Client/AtomFeed.cs
@@ -23,7 +23,6 @@ namespace Splunk.Client
     using System;
     using System.Collections.Generic;
     using System.Collections.ObjectModel;
-    using System.Diagnostics.Contracts;
     using System.Globalization;
     using System.IO;
     using System.Threading.Tasks;

--- a/src/Splunk.Client/Splunk/Client/AuthenticationFailureException.cs
+++ b/src/Splunk.Client/Splunk/Client/AuthenticationFailureException.cs
@@ -23,7 +23,6 @@ namespace Splunk.Client
     using System;
     using System.Collections.ObjectModel;
     using System.Diagnostics.CodeAnalysis;
-    using System.Diagnostics.Contracts;
     using System.Net;
     using System.Net.Http;
 

--- a/src/Splunk.Client/Splunk/Client/BadRequestException.cs
+++ b/src/Splunk.Client/Splunk/Client/BadRequestException.cs
@@ -23,7 +23,6 @@ namespace Splunk.Client
     using System;
     using System.Collections.ObjectModel;
     using System.Diagnostics.CodeAnalysis;
-    using System.Diagnostics.Contracts;
     using System.Net;
     using System.Net.Http;
 

--- a/src/Splunk.Client/Splunk/Client/BaseEntity.cs
+++ b/src/Splunk.Client/Splunk/Client/BaseEntity.cs
@@ -21,7 +21,6 @@ namespace Splunk.Client
     using System;
     using System.Diagnostics.CodeAnalysis;
     using System.Diagnostics.Contracts;
-    using System.Dynamic;
     using System.Threading.Tasks;
 
     /// <summary>

--- a/src/Splunk.Client/Splunk/Client/BaseResource.cs
+++ b/src/Splunk.Client/Splunk/Client/BaseResource.cs
@@ -25,7 +25,6 @@ namespace Splunk.Client
     using System.Collections.ObjectModel;
     using System.Diagnostics.CodeAnalysis;
     using System.Diagnostics.Contracts;
-    using System.Dynamic;
     using System.Threading.Tasks;
 
     /// <summary>

--- a/src/Splunk.Client/Splunk/Client/Configuration.cs
+++ b/src/Splunk.Client/Splunk/Client/Configuration.cs
@@ -22,7 +22,6 @@ namespace Splunk.Client
 {
     using System;
     using System.Collections.Generic;
-    using System.Diagnostics.Contracts;
     using System.IO;
     using System.Net;
     using System.Threading.Tasks;

--- a/src/Splunk.Client/Splunk/Client/ConfigurationStanza.cs
+++ b/src/Splunk.Client/Splunk/Client/ConfigurationStanza.cs
@@ -23,8 +23,6 @@ namespace Splunk.Client
     using System;
     using System.Collections;
     using System.Collections.Generic;
-    using System.Collections.ObjectModel;
-    using System.Diagnostics.Contracts;
     using System.IO;
     using System.Net;
     using System.Threading.Tasks;

--- a/src/Splunk.Client/Splunk/Client/Context.cs
+++ b/src/Splunk.Client/Splunk/Client/Context.cs
@@ -18,11 +18,9 @@ namespace Splunk.Client
 {
     using System;
     using System.Collections.Generic;
-    using System.Diagnostics.Contracts;
     using System.Globalization;
     using System.Linq;
     using System.Net.Http;
-    using System.Net;
     using System.Text;
     using System.Threading;
     using System.Threading.Tasks;

--- a/src/Splunk.Client/Splunk/Client/Contract.cs
+++ b/src/Splunk.Client/Splunk/Client/Contract.cs
@@ -14,23 +14,57 @@
  * under the License.
  */
 
+using System;
+
 namespace Splunk.Client
 {
-    #if __MonoCS__
-
-    //// This doesn't seem like it should not be necessary according to 
-    //// Mono 2.8 notes: http://www.mono-project.com/Release_Notes_Mono_2.8
-    //// as it states if the CONTRACTS_FULL compiler directive is not set, the
-    //// calls to Contract should be removed by the compiler. However when
-    //// testing in Xamarin Studio, this does not appear to be the case.
-    public static class Contract
+    /// <summary>
+    /// This class is an implementation of the System.Diagnostics.Contracts class to get around
+    /// <see href="https://github.com/Microsoft/CodeContracts/issues/476">issues with CCRewrite on newer versions of
+    /// Visual Studio.</see>
+    /// Contains static methods for representing program contracts.
+    /// </summary>
+    internal static class Contract
     {
-        public static void Requires (bool check, string name="") 
-        { }
+        /// <summary>
+        /// Ensure that a certain condition is met and throws an exception if it is not.
+        /// </summary>
+        /// <param name="condition">Condition to be met.</param>
+        /// <exception cref="System.ArgumentException">If condition is false.</exception>
+        internal static void Requires(bool condition)
+        {
+            if (!condition)
+            {
+                throw new ArgumentException();
+            }
+        }
 
-        public static void Requires<T> (bool check, string name="")
-        { }
+        /// <summary>
+        /// Ensure that a certain condition is met and throw an exception of <typeparamref name="T"/> if it is not.
+        /// </summary>
+        /// <typeparam name="T">Type of exception to throw.</typeparam>
+        /// <param name="condition">Condition to be met.</param>
+        /// <param name="message">Message in the exception to throw if condition is not met.</param>
+        /// <exception cref="System.Exception">If condition is false.</exception>
+        internal static void Requires<T>(bool condition, string message) where T : Exception
+        {
+            if (!condition)
+            {
+                throw (T)Activator.CreateInstance(typeof(T), message);
+            }
+        }
+
+        /// <summary>
+        /// Ensure that a certain condition is met and throw an exception of <typeparamref name="T"/> if it is not.
+        /// </summary>
+        /// <typeparam name="T">Type of exception to throw.</typeparam>
+        /// <param name="condition">Condition to be met.</param>
+        internal static void Requires<T>(bool condition) where T : Exception, new()
+        {
+            if (!condition)
+            {
+                throw new T();
+            }
+        }
     }
-
-    #endif
 }

--- a/src/Splunk.Client/Splunk/Client/Endpoint.cs
+++ b/src/Splunk.Client/Splunk/Client/Endpoint.cs
@@ -17,7 +17,6 @@
 namespace Splunk.Client
 {
     using System;
-    using System.Diagnostics.Contracts;
     using System.IO;
 
     /// <summary>

--- a/src/Splunk.Client/Splunk/Client/Entity.cs
+++ b/src/Splunk.Client/Splunk/Client/Entity.cs
@@ -18,7 +18,6 @@ namespace Splunk.Client
 {
     using System;
     using System.Collections.Generic;
-    using System.Diagnostics.Contracts;
     using System.Globalization;
     using System.IO;
     using System.Linq;

--- a/src/Splunk.Client/Splunk/Client/ExpandoAdapter.cs
+++ b/src/Splunk.Client/Splunk/Client/ExpandoAdapter.cs
@@ -20,7 +20,6 @@ namespace Splunk.Client
     using System.Collections.Generic;
     using System.Diagnostics;
     using System.Diagnostics.CodeAnalysis;
-    using System.Diagnostics.Contracts;
     using System.Dynamic;
 
     /// <summary>

--- a/src/Splunk.Client/Splunk/Client/Index.cs
+++ b/src/Splunk.Client/Splunk/Client/Index.cs
@@ -21,7 +21,6 @@
 namespace Splunk.Client
 {
     using System;
-    using System.Diagnostics.Contracts;
     using System.Linq;
     using System.Net;
     using System.Threading.Tasks;

--- a/src/Splunk.Client/Splunk/Client/InternalServerErrorException.cs
+++ b/src/Splunk.Client/Splunk/Client/InternalServerErrorException.cs
@@ -23,7 +23,6 @@ namespace Splunk.Client
     using System;
     using System.Collections.ObjectModel;
     using System.Diagnostics.CodeAnalysis;
-    using System.Diagnostics.Contracts;
     using System.Net;
     using System.Net.Http;
 

--- a/src/Splunk.Client/Splunk/Client/Job.cs
+++ b/src/Splunk.Client/Splunk/Client/Job.cs
@@ -21,7 +21,6 @@ namespace Splunk.Client
     using System.Collections.ObjectModel;
     using System.ComponentModel;
     using System.Diagnostics.CodeAnalysis;
-    using System.Diagnostics.Contracts;
     using System.IO;
     using System.Linq;
     using System.Net;

--- a/src/Splunk.Client/Splunk/Client/Message.cs
+++ b/src/Splunk.Client/Splunk/Client/Message.cs
@@ -23,7 +23,6 @@ namespace Splunk.Client
     using System;
     using System.Collections.Generic;
     using System.Collections.ObjectModel;
-    using System.Diagnostics.Contracts;
     using System.Threading.Tasks;
     using System.Xml;
 

--- a/src/Splunk.Client/Splunk/Client/Namespace.cs
+++ b/src/Splunk.Client/Splunk/Client/Namespace.cs
@@ -22,7 +22,6 @@ namespace Splunk.Client
 {
     using System;
     using System.Diagnostics.CodeAnalysis;
-    using System.Diagnostics.Contracts;
 
     /// <summary>
     /// Specifies the user/app context for a resource.

--- a/src/Splunk.Client/Splunk/Client/Observable.cs
+++ b/src/Splunk.Client/Splunk/Client/Observable.cs
@@ -23,7 +23,6 @@ namespace Splunk.Client
 {
     using System;
     using System.Collections.Generic;
-    using System.Diagnostics.Contracts;
     using System.Threading.Tasks;
 
     /// <summary>

--- a/src/Splunk.Client/Splunk/Client/Observer.cs
+++ b/src/Splunk.Client/Splunk/Client/Observer.cs
@@ -16,21 +16,7 @@
 
 namespace Splunk.Client
 {
-    using Splunk.Client;
     using System;
-    using System.Collections.Generic;
-    using System.Diagnostics;
-    using System.Diagnostics.Contracts;
-    using System.IO;
-    using System.IO.Compression;
-    using System.Linq;
-    using System.Net;
-    using System.Net.Http;
-    using System.Runtime.Serialization;
-    using System.Runtime.Serialization.Json;
-    using System.Text;
-    using System.Threading;
-    using System.Threading.Tasks;
 
     /// <summary>
     /// Provides a class for faking git requests and responses from a Splunk server.

--- a/src/Splunk.Client/Splunk/Client/Pagination.cs
+++ b/src/Splunk.Client/Splunk/Client/Pagination.cs
@@ -21,7 +21,6 @@
 namespace Splunk.Client
 {
     using System;
-    using System.Diagnostics.Contracts;
     using System.Globalization;
 
     /// <summary>

--- a/src/Splunk.Client/Splunk/Client/RequestException.cs
+++ b/src/Splunk.Client/Splunk/Client/RequestException.cs
@@ -24,8 +24,6 @@ namespace Splunk.Client
     using System.Collections.Generic;
     using System.Collections.ObjectModel;
     using System.Diagnostics.CodeAnalysis;
-    using System.Diagnostics.Contracts;
-    using System.Linq;
     using System.Net;
     using System.Net.Http;
     using System.Text;

--- a/src/Splunk.Client/Splunk/Client/ResourceName.cs
+++ b/src/Splunk.Client/Splunk/Client/ResourceName.cs
@@ -24,8 +24,6 @@ namespace Splunk.Client
     using System.Collections.Generic;
     using System.Collections.ObjectModel;
     using System.Diagnostics.CodeAnalysis;
-    using System.Diagnostics.Contracts;
-    using System.Globalization;
     using System.Linq;
 
     /// <summary>

--- a/src/Splunk.Client/Splunk/Client/ResourceNotFoundException.cs
+++ b/src/Splunk.Client/Splunk/Client/ResourceNotFoundException.cs
@@ -23,7 +23,6 @@ namespace Splunk.Client
     using System;
     using System.Collections.ObjectModel;
     using System.Diagnostics.CodeAnalysis;
-    using System.Diagnostics.Contracts;
     using System.Net;
     using System.Net.Http;
 

--- a/src/Splunk.Client/Splunk/Client/Response.cs
+++ b/src/Splunk.Client/Splunk/Client/Response.cs
@@ -17,7 +17,6 @@
 namespace Splunk.Client
 {
     using System;
-    using System.Diagnostics.Contracts;
     using System.IO;
     using System.Net;
     using System.Net.Http;

--- a/src/Splunk.Client/Splunk/Client/SavedSearch.cs
+++ b/src/Splunk.Client/Splunk/Client/SavedSearch.cs
@@ -25,8 +25,6 @@ namespace Splunk.Client
     using System.Collections.ObjectModel;
     using System.ComponentModel;
     using System.Diagnostics.CodeAnalysis;
-    using System.Diagnostics.Contracts;
-    using System.IO;
     using System.Linq;
     using System.Net;
     using System.Runtime.Serialization;

--- a/src/Splunk.Client/Splunk/Client/SearchPreview.cs
+++ b/src/Splunk.Client/Splunk/Client/SearchPreview.cs
@@ -24,7 +24,6 @@ namespace Splunk.Client
     using System;
     using System.Collections.Generic;
     using System.Collections.ObjectModel;
-    using System.Diagnostics.Contracts;
     using System.Threading.Tasks;
     using System.Xml;
 

--- a/src/Splunk.Client/Splunk/Client/SearchResult.cs
+++ b/src/Splunk.Client/Splunk/Client/SearchResult.cs
@@ -22,8 +22,6 @@ namespace Splunk.Client
     using System.Collections.Immutable;
     using System.Collections.ObjectModel;
     using System.Diagnostics;
-    using System.Diagnostics.Contracts;
-    using System.Dynamic;
     using System.Linq;
     using System.Text;
     using System.Threading.Tasks;

--- a/src/Splunk.Client/Splunk/Client/Server.cs
+++ b/src/Splunk.Client/Splunk/Client/Server.cs
@@ -21,7 +21,6 @@
 namespace Splunk.Client
 {
     using System;
-    using System.Diagnostics.Contracts;
     using System.Net;
     using System.Net.Http;
     using System.Threading;

--- a/src/Splunk.Client/Splunk/Client/ServerMessage.cs
+++ b/src/Splunk.Client/Splunk/Client/ServerMessage.cs
@@ -22,7 +22,6 @@ namespace Splunk.Client
 {
     using System;
     using System.Collections.Generic;
-    using System.Diagnostics.Contracts;
     using System.IO;
     using System.Linq;
     using System.Threading.Tasks;

--- a/src/Splunk.Client/Splunk/Client/Service.cs
+++ b/src/Splunk.Client/Splunk/Client/Service.cs
@@ -24,7 +24,6 @@ namespace Splunk.Client
     using System.Collections.Generic;
     using System.Collections.ObjectModel;
     using System.ComponentModel;
-    using System.Diagnostics.Contracts;
     using System.IO;
     using System.Linq;
     using System.Net;

--- a/src/Splunk.Client/Splunk/Client/StoragePassword.cs
+++ b/src/Splunk.Client/Splunk/Client/StoragePassword.cs
@@ -22,7 +22,6 @@
 namespace Splunk.Client
 {
     using System;
-    using System.Diagnostics.Contracts;
     using System.IO;
     using System.Net;
     using System.Text;

--- a/src/Splunk.Client/Splunk/Client/Transmitter.cs
+++ b/src/Splunk.Client/Splunk/Client/Transmitter.cs
@@ -21,7 +21,6 @@
 namespace Splunk.Client
 {
     using System;
-    using System.Diagnostics.Contracts;
     using System.IO;
     using System.Linq;
     using System.Net;

--- a/src/Splunk.Client/Splunk/Client/UnauthorizedAccessException.cs
+++ b/src/Splunk.Client/Splunk/Client/UnauthorizedAccessException.cs
@@ -23,7 +23,6 @@ namespace Splunk.Client
     using System;
     using System.Collections.ObjectModel;
     using System.Diagnostics.CodeAnalysis;
-    using System.Diagnostics.Contracts;
     using System.Net;
     using System.Net.Http;
 

--- a/src/Splunk.Client/Splunk/Client/XmlReaderExtensions.cs
+++ b/src/Splunk.Client/Splunk/Client/XmlReaderExtensions.cs
@@ -17,7 +17,6 @@
 namespace Splunk.Client
 {
     using System;
-    using System.Diagnostics.Contracts;
     using System.Globalization;
     using System.IO;
     using System.Linq;

--- a/src/Splunk.ModularInputs/Splunk/ModularInputs/SingleValueParameter.cs
+++ b/src/Splunk.ModularInputs/Splunk/ModularInputs/SingleValueParameter.cs
@@ -17,7 +17,6 @@
 namespace Splunk.ModularInputs
 {
     using System;
-    using System.Collections.ObjectModel;
     using System.Diagnostics.Contracts;
     using System.Xml.Serialization;
 


### PR DESCRIPTION
Newer versions of VS are having issues with CCRewrite and it turns out this is something that is going to die out in the future as Microsoft is reluctant on maintaining this. (see https://github.com/Microsoft/CodeContracts/issues/476) 

This PR implements the `System.Diagnostics.Requires` functions in the Requires class. Since this is in the same namespace as the other classes, all the existing calls to `System.Diagnostics.Requires` are redirected to this implementation. As a result, the CCRewrite is no longer required to be installed on machines wanting to use this framework which simplifies development (and deployment) a lot. It also fixes the issue discussed on https://github.com/splunk/splunk-sdk-csharp-pcl/issues/42 