### PR TITLE
Remove all references to clear password

### DIFF
--- a/src/Splunk.Client/Splunk/Client/IStoragePassword.cs
+++ b/src/Splunk.Client/Splunk/Client/IStoragePassword.cs
@@ -32,15 +32,6 @@ namespace Splunk.Client
         #region Properties
 
         /// <summary>
-        /// Gets the plain text version of the current <see cref= "StoragePassword"/>.
-        /// </summary>
-        /// <value>
-        /// The clear password.
-        /// </value>
-        string ClearPassword
-        { get; }
-
-        /// <summary>
         /// Gets the extensible administration interface properties for the current
         /// <see cref= "StoragePassword"/>.
         /// </summary>
@@ -137,7 +128,6 @@ namespace Splunk.Client
     {
         #region Properties
 
-        public abstract string ClearPassword { get; }
         public abstract Eai Eai { get; }
         public abstract string EncryptedPassword { get; }
         public abstract string Password { get; }

--- a/src/Splunk.Client/Splunk/Client/StoragePassword.cs
+++ b/src/Splunk.Client/Splunk/Client/StoragePassword.cs
@@ -144,12 +144,6 @@ namespace Splunk.Client
         #region Properties
 
         /// <inheritdoc/>
-        public virtual string ClearPassword
-        {
-            get { return this.Content.GetValue("ClearPassword", StringConverter.Instance); }
-        }
-
-        /// <inheritdoc/>
         public virtual Eai Eai
         {
             get { return this.Content.GetValue("Eai", Eai.Converter.Instance); }

--- a/test/acceptance-tests/TestService.cs
+++ b/test/acceptance-tests/TestService.cs
@@ -113,7 +113,6 @@ namespace Splunk.Client.AcceptanceTests
 
                         StoragePassword sp = await sps.CreateAsync(password, username, realm);
 
-                        Assert.Equal(password, sp.ClearPassword);
                         Assert.Equal(username, sp.Username);
                         Assert.Equal(realm, sp.Realm);
 
@@ -136,7 +135,6 @@ namespace Splunk.Client.AcceptanceTests
                         password = MockContext.GetOrElse(Membership.GeneratePassword(15, 2));
                         await sp.UpdateAsync(password);
 
-                        Assert.Equal(password, sp.ClearPassword);
                         Assert.Equal(username, sp.Username);
                         Assert.Equal(realm, sp.Realm);
 
@@ -328,7 +326,6 @@ namespace Splunk.Client.AcceptanceTests
 
                             StoragePassword sp = await service.StoragePasswords.CreateAsync(password, username, realm);
 
-                            Assert.Equal(password, sp.ClearPassword);
                             Assert.Equal(username, sp.Username);
                             Assert.Equal(realm, sp.Realm);
                         }

--- a/test/unit-tests/Data/Client/StoragePassword.GetAsync.xml
+++ b/test/unit-tests/Data/Client/StoragePassword.GetAsync.xml
@@ -29,7 +29,6 @@
     <link href="/servicesNS/nobody/search/storage/passwords/splunk.com%3Afoobar%3A" rel="remove"/>
     <content type="text/xml">
       <s:dict>
-        <s:key name="clear_password">t]&gt;Wj9zAl-c5%nG</s:key>
         <s:key name="eai:acl">
           <s:dict>
             <s:key name="app">search</s:key>

--- a/test/unit-tests/TestStoragePasswordCollection.cs
+++ b/test/unit-tests/TestStoragePasswordCollection.cs
@@ -124,7 +124,6 @@ namespace Splunk.Client.UnitTests
             CheckCommonProperties(entry.Title, password);
             CheckEai(password);
 
-            Assert.Equal(entry.Content["ClearPassword"], password.ClearPassword);
             Assert.Equal(entry.Content["EncrPassword"], password.EncryptedPassword);
             Assert.Equal(entry.Content["Password"], password.Password);
             Assert.Equal(entry.Content["Username"], password.Username);


### PR DESCRIPTION
POST requests to the /storage/passwords endpoint should not return the clear_password back in plaintext. Therefore we should remove all references to clear_password.

I removed all references to clear_password in the SDK, including for the tests.