### PR TITLE
Remove clear password POST assertions

### DIFF
--- a/test/acceptance-tests/TestService.cs
+++ b/test/acceptance-tests/TestService.cs
@@ -113,7 +113,6 @@ namespace Splunk.Client.AcceptanceTests
 
                         StoragePassword sp = await sps.CreateAsync(password, username, realm);
 
-                        Assert.Equal(password, sp.ClearPassword);
                         Assert.Equal(username, sp.Username);
                         Assert.Equal(realm, sp.Realm);
 
@@ -136,7 +135,6 @@ namespace Splunk.Client.AcceptanceTests
                         password = MockContext.GetOrElse(Membership.GeneratePassword(15, 2));
                         await sp.UpdateAsync(password);
 
-                        Assert.Equal(password, sp.ClearPassword);
                         Assert.Equal(username, sp.Username);
                         Assert.Equal(realm, sp.Realm);
 
@@ -328,7 +326,6 @@ namespace Splunk.Client.AcceptanceTests
 
                             StoragePassword sp = await service.StoragePasswords.CreateAsync(password, username, realm);
 
-                            Assert.Equal(password, sp.ClearPassword);
                             Assert.Equal(username, sp.Username);
                             Assert.Equal(realm, sp.Realm);
                         }

--- a/test/unit-tests/Data/Client/StoragePassword.GetAsync.xml
+++ b/test/unit-tests/Data/Client/StoragePassword.GetAsync.xml
@@ -29,7 +29,6 @@
     <link href="/servicesNS/nobody/search/storage/passwords/splunk.com%3Afoobar%3A" rel="remove"/>
     <content type="text/xml">
       <s:dict>
-        <s:key name="clear_password">t]&gt;Wj9zAl-c5%nG</s:key>
         <s:key name="eai:acl">
           <s:dict>
             <s:key name="app">search</s:key>


### PR DESCRIPTION
POST requests to the /storage/passwords endpoint should not return the clear_password back in plaintext. Therefore we should remove all POST assertions that check clear_password.