### PR TITLE
Handle null in NormalizePropertyName

### DIFF
--- a/src/Splunk.Client/Splunk/Client/AtomEntry.cs
+++ b/src/Splunk.Client/Splunk/Client/AtomEntry.cs
@@ -267,6 +267,10 @@ namespace Splunk.Client
 
         static string NormalizePropertyName(string name)
         {
+            if (string.IsNullOrEmpty(name))
+            {
+                return "";
+            }
             Contract.Requires<ArgumentException>(!string.IsNullOrEmpty(name));
             var builder = new StringBuilder(name.Length);
             int index = 0;


### PR DESCRIPTION
Checking status was throwing an exception here when name was null, preventing us getting results.